### PR TITLE
Update SliderHome plugin dependencies and fix deprecations

### DIFF
--- a/SliderHomePlugin.inc.php
+++ b/SliderHomePlugin.inc.php
@@ -10,7 +10,7 @@ import('lib.pkp.classes.plugins.GenericPlugin');
 
 /**
  * @class SliderHomePlugin
- * 
+ *
  * @brief Enables display of image slider on the journal/press home page.
  */
 class SliderHomePlugin extends GenericPlugin {
@@ -22,10 +22,14 @@ class SliderHomePlugin extends GenericPlugin {
 	/**
 	 * @copydoc Plugin::register()
 	 */
-	function register($category, $path, $mainContextId = null) {	
-	
+	function register($category, $path, $mainContextId = null) {
+
 		if (parent::register($category, $path, $mainContextId)) {
 			if ($this->getEnabled($mainContextId)) {
+				import('plugins.generic.sliderHome.classes.SliderHomeDAO');
+				$sliderHomeDao = new SliderHomeDAO();
+				DAORegistry::registerDAO('SliderHomeDao', $sliderHomeDao);
+
 				HookRegistry::register('TemplateManager::display',array($this, 'callbackDisplay')); //to enable slider display in OMP frontend
 				HookRegistry::register('Template::Settings::website::appearance', array($this, 'callbackAppearanceTab')); //to enable display of plugin settings tab
 				HookRegistry::register('LoadComponentHandler', array($this, 'setupGridHandler')); //to load (old style) grid handler for image uploadd form
@@ -44,17 +48,17 @@ class SliderHomePlugin extends GenericPlugin {
 		$handler = new SliderHomeSettingsTabFormHandler();
 
 		// add the new endpoint
-		$endpoints['POST'][] = 
+		$endpoints['POST'][] =
 			[
 				'pattern' => '/{contextPath}/api/{version}/contexts/{contextId}/sliderSettings',
 				'handler' => [$handler, 'saveFormData'],
 				'roles' => array(ROLE_ID_SITE_ADMIN, ROLE_ID_MANAGER)
 			];
 	}
-	
+
 	// OMP/OJS 3.2: Add tab for slider content grid in website settings appearance
 	function callbackAppearanceTab($hookName, $args) {
-		# prepare data
+		// prepare data
 		$templateMgr =& $args[1];
 		$output =& $args[2];
 		$request =& Registry::get('request');
@@ -81,15 +85,15 @@ class SliderHomePlugin extends GenericPlugin {
 		);
 		$contextUrl = $request->getRouter()->url($request, $context->getPath());
 
-		# get data to initilaize ComponentForm 
+		// get data to initilaize ComponentForm
 		$maxHeight = $this->getSetting($contextId, 'maxHeight');
-		if (!$maxHeight) { 
+		if (!$maxHeight) {
 			// set default value
 			$maxHeight = 100;
 			$this->updateSetting($contextId, 'maxHeight', $maxHeight, $type = null, $isLocalized = false);
 		}
 		$speed = $this->getSetting($contextId, 'speed');
-		if (!$speed) { 
+		if (!$speed) {
 			// set default value
 			$speed = 2000;
 			$this->updateSetting($contextId, 'speed', $speed, $type = null, $isLocalized = false);
@@ -112,7 +116,7 @@ class SliderHomePlugin extends GenericPlugin {
 			]
 		);
 
-		# setup template
+		// setup template
 		$templateMgr->setConstants([
 			'FORM_SLIDER_SETTINGS',
 		]);
@@ -128,21 +132,21 @@ class SliderHomePlugin extends GenericPlugin {
 	}
 
 	// OJS: there's a template hook on the frontend journal index page
-	function callbackIndexJournal($hookName, $args) {	
+	function callbackIndexJournal($hookName, $args) {
 		$request = $this->getRequest();
 
 		$output =& $args[2];
 		$output .= $this->getSliderContent($request);
 
 		return false;
-	}	
-		
+	}
+
 	// OMP: no template hook on the index template -> use display hook to replace template
 	function callbackDisplay($hookName, $args) {
 		$request = $this->getRequest();
 		$templateMgr =& $args[0];
 		$template =& $args[1];
-		$applicationName = PKPApplication::get()->getName();		
+		$applicationName = PKPApplication::get()->getName();
 		switch ($template) {
 			case 'frontend/pages/index.tpl':
 				if ($applicationName=="omp") {
@@ -150,14 +154,14 @@ class SliderHomePlugin extends GenericPlugin {
 					$templateMgr->assign('sliderContent',$sliderContent);
 					$this->addHeader($templateMgr,$request->getBaseUrl());
 					$templateMgr->display($this->getTemplateResource('homeOMP.tpl'));
-					return true;					
+					return true;
 				}
 			case 'frontend/pages/indexJournal.tpl':
 				$this->addHeader($templateMgr,$request->getBaseUrl());
 		}
 		return false;
 	}
-	
+
 	private function addHeader($templateMgr,$baseUrl) {
 		$templateMgr->addHeader(
 			'slider',
@@ -166,18 +170,18 @@ class SliderHomePlugin extends GenericPlugin {
 		$templateMgr->addHeader(
 			'swiper-min',
 			"<link rel='stylesheet' href='".$baseUrl."/plugins/generic/sliderHome/swiper/css/swiper-bundle.min.css'>"
-		);		
+		);
 		$templateMgr->addHeader(
 			'swiper-min-js',
 			"<script src='".$baseUrl."/plugins/generic/sliderHome/swiper/js/swiper-bundle.min.js'></script>"
 		);
 	}
-	
+
 	// get markup for slider content, incl. containers/wrappers
 	private function getSliderContent($request) {
 
 		$templateMgr = TemplateManager::getManager($request);
-		$locale = $templateMgr->getTemplateVars('currentLocale'); 
+		$locale = $templateMgr->getTemplateVars('currentLocale');
 		$context = $request->getContext();
 		$primaryLocale = $context->getPrimaryLocale();
 		$contextPath = get_class($context) === 'Press'?'/presses/':'/journals/';
@@ -188,8 +192,8 @@ class SliderHomePlugin extends GenericPlugin {
 		$stopOnLastSlide = $this->getSetting($contextId, 'stopOnLastSlide')?"true":"false";
 		$fallbackLocale = $this->getSetting($contextId, 'fallbackLocale')?:"usePrimary";
 
-		import('plugins.generic.sliderHome.classes.SliderHomeDAO');
-		$sliderHomeDao = new SliderHomeDao();
+		/** @var SliderHomeDAO $sliderHomeDao */
+		$sliderHomeDao = DAORegistry::getDAO('SliderHomeDao');
 
 		# get slider content based on locale to show
 		if ($fallbackLocale =='usePrimary') {
@@ -209,7 +213,7 @@ class SliderHomePlugin extends GenericPlugin {
 		} else {
 			$contentArray = $sliderHomeDao->getAllContent($contextId, $locale);
 		};
-		
+
 		$sliderContent = "";
 
 		if (!empty($contentArray)) {
@@ -230,7 +234,7 @@ class SliderHomePlugin extends GenericPlugin {
 				// create slider fiure and image tag
 				// figure
 				$sliderFigure = $contentHTML->createElement("figure");
-				
+
 				$baseUrl = Config::getVar('general', 'base_url');
 				$publicFilesDir = Config::getVar('files', 'public_files_dir');
 
@@ -249,8 +253,8 @@ class SliderHomePlugin extends GenericPlugin {
 					$sliderFigure->appendChild($sliderImgLink);
 				} else {
 					$sliderFigure->appendChild($sliderImg);
-				}				
-				
+				}
+
 				if ($value['copyright']) {
 					$smallTag = $contentHTML->createElement("small", $value['copyright']);
 					$smallTag->setAttribute('class',"slider-copyright");
@@ -282,9 +286,9 @@ class SliderHomePlugin extends GenericPlugin {
 				$sliderContent.= $contentHTML->saveHTML($slide);
 
 			}
-			// add slider navigation 
+			// add slider navigation
 			$sliderContent.= "</div><div class='swiper-pagination'></div><div class='swiper-button-prev'></div><div class='swiper-button-next'></div></div>";
-			$sliderContent .= 
+			$sliderContent .=
 			"<script>
 				var swiper = new Swiper('.swiper-container', {
 					autoHeight: true, //enable auto height
@@ -305,19 +309,19 @@ class SliderHomePlugin extends GenericPlugin {
 			</script>";
 		}
 		return $sliderContent;
-	}	
-	
+	}
+
 	/**
 	 * Set up handler
 	 */
 	function setupGridHandler($hookName, $params) {
-		
+
 		$component =& $params[0];
-		if ($component == 'plugins.generic.sliderHome.controllers.grid.SliderHomeGridHandler') {			
+		if ($component == 'plugins.generic.sliderHome.controllers.grid.SliderHomeGridHandler') {
 			import($component);
 			SliderHomeGridHandler::setPlugin($this);
 			return true;
-		}	
+		}
 		return false;
 	}
 

--- a/classes/SliderContent.inc.php
+++ b/classes/SliderContent.inc.php
@@ -4,7 +4,7 @@
  *
  * Copyright (c) 2021 Universitätsbibliothek Freie Universität Berlin
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
- * 
+ *
  * @brief File implemeting the slider content data object.
  */
 
@@ -16,10 +16,10 @@ class SliderContent extends DataObject {
 
 	/**
 	 * Constructor
-	 */	
+	 */
 	function __construct() {
 		parent::__construct();
-	} 
+	}
 
 	//
 	// Get/set methods
@@ -64,7 +64,7 @@ class SliderContent extends DataObject {
 
 	function setShowContent($showContent) {
 		$this->setData('showContent', $showContent);
-	}	
+	}
 
 	function getSequence() {
 		return $this->getData('sequence');
@@ -81,7 +81,7 @@ class SliderContent extends DataObject {
 	function setSliderImage($filename) {
 		$this->setData('sliderImage', $filename);
 	}
-	
+
 	function getSliderImageLink() {
 		return $this->getData('sliderImageLink')?:"";
 	}
@@ -99,7 +99,7 @@ class SliderContent extends DataObject {
 	}
 
 	function getLocale() {
-		$request = Application::getRequest();
+		$request = Application::get()->getRequest();
 		return $request->getContext()->getPrimaryLocale();
 	}
 }

--- a/classes/SliderHomeDAO.inc.php
+++ b/classes/SliderHomeDAO.inc.php
@@ -54,14 +54,14 @@ class SliderHomeDAO extends SchemaDAO {
 			}
 			$result[] = $data;
 		}
-		
+
 		return $result;
 	}
 
 	function getByContextId($contextId, $rangeInfo = null) {
 		$result = Capsule::table('slider')
 		->where('context_id', $contextId)
-		->orderBy('sequence')	
+		->orderBy('sequence')
 		->get();
 		return new DAOResultFactory($result, $this, '_fromRow');
 	}
@@ -72,7 +72,7 @@ class SliderHomeDAO extends SchemaDAO {
 		->max('sequence');
 	}
 
-	function insertObject($sliderContent) {	
+	function insertObject($sliderContent) {
 		Capsule::table('slider')->insert([
 			'context_id' => (int) $sliderContent->getContextId(),
 			'sequence' => $sliderContent->getSequence(),
@@ -83,7 +83,7 @@ class SliderHomeDAO extends SchemaDAO {
 
 		$this->updateDataObjectSettings('slider_settings', $sliderContent, [
 			'slider_content_id' => $sliderContent->getId()
-		]);		
+		]);
 
 		return $sliderContent->getId();
 	}
@@ -101,7 +101,7 @@ class SliderHomeDAO extends SchemaDAO {
 			'slider_content_id' => $sliderContent->getId()
 		]);
 	}
-	
+
 	function deleteById($sliderContentId) {
 		Capsule::table('slider')
 		->where('slider_content_id', $sliderContentId)
@@ -120,6 +120,7 @@ class SliderHomeDAO extends SchemaDAO {
 	}
 
 	function _fromRow($row) {
+		/** @var SliderContent $sliderContent */
 		$sliderContent = $this->newDataObject();
 		$sliderContent->setId($row['slider_content_id']);
 		$sliderContent->setContextId($row['context_id']);

--- a/classes/components/form/context/SliderHomeSettingsForm.inc.php
+++ b/classes/components/form/context/SliderHomeSettingsForm.inc.php
@@ -4,7 +4,7 @@
  *
  * Copyright (c) 2021 Universitätsbibliothek Freie Universität Berlin
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING..
- * 
+ *
  * @brief File implemnting SliderHomeSettingsForm
  */
 
@@ -16,11 +16,14 @@ define('FORM_SLIDER_SETTINGS', 'sliderSettings');
 
 /**
  * A form for implementing slider settings.
- * 
+ *
  * @class SliderHomeSettingsForm
  * @brief Class implemnting SliderHomeSettingsForm
  */
 class SliderHomeSettingsForm extends FormComponent {
+
+	public $successMessage;
+
 	/** @copydoc FormComponent::$id */
 	public $id = FORM_SLIDER_SETTINGS;
 

--- a/controllers/grid/SliderHomeGridHandler.inc.php
+++ b/controllers/grid/SliderHomeGridHandler.inc.php
@@ -35,16 +35,16 @@ class SliderHomeGridHandler extends GridHandler {
 
 	/**
 	 * Constructor
-	 */	
+	 */
 	function __construct() {
-		parent::__construct();	
+		parent::__construct();
 		$this->addRoleAssignment(
 			array(ROLE_ID_MANAGER,ROLE_ID_SITE_ADMIN),
 			array('index', 'fetchGrid', 'fetchRow','addSliderContent',
 				'editSliderContent', 'updateSliderContent', 'delete','saveSequence',
 				'uploadFile', 'deleteCoverImage')
 		);
-	} 
+	}
 
 	//
 	// Overridden template methods
@@ -135,7 +135,8 @@ class SliderHomeGridHandler extends GridHandler {
 			$contextId = $context->getId();
 		}
 
-		$sliderHomeDao = new SliderHomeDAO(); 
+		/** @var SliderHomeDAO $sliderHomeDao */
+		$sliderHomeDao = DAORegistry::getDAO('SliderHomeDao');
 		return $sliderHomeDao->getByContextId($contextId);
 	}
 
@@ -145,8 +146,8 @@ class SliderHomeGridHandler extends GridHandler {
 	function initFeatures($request, $args) {
 		import('lib.pkp.classes.controllers.grid.feature.OrderGridItemsFeature');
 		return array(new OrderGridItemsFeature());
-	}	
-	
+	}
+
 	/**
 	 * @copydoc GridHandler::getRowInstance()
 	 */
@@ -154,12 +155,12 @@ class SliderHomeGridHandler extends GridHandler {
 		import('plugins.generic.sliderHome.controllers.grid.SliderHomeGridRow');
 		return new SliderHomeGridRow();
 	}
-	
+
 	//
 	// Public Grid Actions
 	//
 	/**
-	 * Display the grid's containing page. 
+	 * Display the grid's containing page.
 	 * for OJS 3.1.2
 	 * @param $args array
 	 * @param $request PKPRequest
@@ -169,9 +170,9 @@ class SliderHomeGridHandler extends GridHandler {
 		import('lib.pkp.classes.form.Form');
 		$form = new Form(self::$plugin->getTemplateResource('websiteSettingsTab.tpl'));
 
-		return new JSONMessage(true, $form->fetch($request));		
+		return new JSONMessage(true, $form->fetch($request));
 	}
-	
+
 	/**
 	 * An action to add a new user
 	 * @param $args array Arguments to the request
@@ -195,7 +196,7 @@ class SliderHomeGridHandler extends GridHandler {
 		if ($context) {
 			$contextId = $context->getId();
 		}
-	
+
 		$sliderContentForm = new SliderContentForm($request, self::$plugin, $contextId, $sliderContentId);
 		$sliderContentForm->initData();
 
@@ -209,26 +210,26 @@ class SliderHomeGridHandler extends GridHandler {
 	 * @return string Serialized JSON object
 	 */
 	function updateSliderContent($args, $request) {
-		$sliderContentId = $request->getUserVar('sliderContentId');		
+		$sliderContentId = $request->getUserVar('sliderContentId');
 		$context = $request->getContext();
 		$contextId = CONTEXT_ID_NONE;
 		if ($context) {
 			$contextId = $context->getId();
-		}		
+		}
 
 		$sliderContentForm = new SliderContentForm($request, self::$plugin, $contextId, $sliderContentId);
-		$sliderContentForm->readInputData();		
+		$sliderContentForm->readInputData();
 		// Check the results
-		if ($sliderContentForm->validate()) {			
-			// Save the results			
-			$sliderContentForm->execute();			
+		if ($sliderContentForm->validate()) {
+			// Save the results
+			$sliderContentForm->execute();
  			return DAO::getDataChangedEvent($sliderContentId);
-		} else {		
+		} else {
 			return new JSONMessage(false);
 		}
 	}
 
-	/**                               
+	/**
 	 * @param $args array
 	 * Delete a user
 	 * @param $request PKPRequest
@@ -241,10 +242,20 @@ class SliderHomeGridHandler extends GridHandler {
 		$contextId = CONTEXT_ID_NONE;
 		if ($context) {
 			$contextId = $context->getId();
-		}		
+		}
 
-		$sliderHomeDao = new SliderHomeDAO();
+		/** @var SliderHomeDAO $sliderHomeDao */
+		$sliderHomeDao = DAORegistry::getDAO('SliderHomeDao');
+
+		/** @var SliderContent $sliderContent */
 		$sliderContent = $sliderHomeDao->getById($sliderContentId, $contextId);
+
+		$publicFileManager = new PublicFileManager();
+
+		$sliderImage = $sliderContent->getSliderImage();
+		if ($sliderImage) {
+			$publicFileManager->removeContextFile($contextId, $sliderImage);
+		}
 
 		$sliderHomeDao->deleteObject($sliderContent);
 
@@ -267,7 +278,11 @@ class SliderHomeGridHandler extends GridHandler {
 		if ($context) {
 			$contextId = $context->getId();
 		}
-		$sliderHomeDao = new SliderHomeDAO();
+
+		/** @var SliderHomeDAO $sliderHomeDao */
+		$sliderHomeDao = DAORegistry::getDAO('SliderHomeDao');
+
+		/** @var SliderContent $sliderContent */
 		$sliderContent = $sliderHomeDao->getById($rowId, $contextId);
 		$sliderContent->setSequence($newSequence);
 		$sliderHomeDao->updateObject($sliderContent);
@@ -298,14 +313,17 @@ class SliderHomeGridHandler extends GridHandler {
 		$contextId = CONTEXT_ID_NONE;
 		if ($context) {
 			$contextId = $context->getId();
-		}		
+		}
 
-		$sliderHomeDao = new SliderHomeDAO();
+		/** @var SliderHomeDAO $sliderHomeDao */
+		$sliderHomeDao = DAORegistry::getDAO('SliderHomeDao');
+
+		/** @var SliderContent $sliderContent */
 		$sliderContent = $sliderHomeDao->getById($sliderContentId, $contextId);
 
 
 		// Check if the passed filename matches the filename for this slider image
-		if ($args['sliderImage'] != $sliderContent->getCoverImage()) {
+		if ($args['sliderImage'] != $sliderContent->getSliderImage()) {
 			return new JSONMessage(false, __('editor.issues.removeCoverImageFileNameMismatch'));
 		}
 
@@ -318,7 +336,7 @@ class SliderHomeGridHandler extends GridHandler {
 
 		// Remove the file
 		$publicFileManager = new PublicFileManager();
-		if ($publicFileManager->removeContextFile($issue->getJournalId(), $file)) {
+		if ($publicFileManager->removeContextFile($contextId, $file)) {
 			$json = new JSONMessage(true);
 			$json->setEvent('fileDeleted');
 			return $json;

--- a/controllers/grid/form/SliderContentForm.inc.php
+++ b/controllers/grid/form/SliderContentForm.inc.php
@@ -10,6 +10,8 @@
  */
 
 import('lib.pkp.classes.form.Form');
+import('plugins.generic.sliderHome.classes.SliderContent');
+import('plugins.generic.sliderHome.classes.SliderHomeDAO');
 
  /**
  * @class SliderContentForm
@@ -18,23 +20,23 @@ import('lib.pkp.classes.form.Form');
 class SliderContentForm extends Form {
 
 	var $request;
-	
+
 	var $contextId;
 
 	var $sliderContentId;
-	
-	var $plugin;	
+
+	var $plugin;
 
 	/**
 	 * Constructor
 	 */
 	function __construct($request, $sliderHomePlugin, $contextId, $sliderContentId = null) {
-		$this->_request = $request;
+		$this->request = $request;
 		$this->contextId = $contextId;
 		$this->sliderContentId = $sliderContentId;
 		$this->plugin = $sliderHomePlugin;
-		
-		parent::__construct($sliderHomePlugin->getTemplateResource('sliderContentForm.tpl'));		
+
+		parent::__construct($sliderHomePlugin->getTemplateResource('sliderContentForm.tpl'));
 
 		// Add form checks
 		$this->addCheck(new FormValidator($this,'name','required', 'plugins.generic.sliderHome.nameRequired'));
@@ -44,30 +46,33 @@ class SliderContentForm extends Form {
 	}
 
 	/**
-	 * Initialize form data 
+	 * Initialize form data
 	 */
 	function initData() {
 
 		if ($this->sliderContentId) {
-			$sliderHomeDao = new SliderHomeDAO();
+			/** @var SliderHomeDAO $sliderHomeDao */
+			$sliderHomeDao = DAORegistry::getDAO('SliderHomeDao');
+
+			/** @var SliderContent $sliderContent */
 			$sliderContent = $sliderHomeDao->getById($this->sliderContentId, $this->contextId);
 			$this->setData('name', $sliderContent->getName());
 			$this->setData('content', $sliderContent->getContent());
 			$this->setData('showContent', $sliderContent->getShowContent());
 			$this->setData('copyright', $sliderContent->getCopyright());
-			
+
 			$locale = AppLocale::getLocale();
 
 			$this->setData('sliderImage', $sliderContent->getSliderImage()?:"");
 			$this->setData('sliderImageLink', $sliderContent->getSliderImageLink()?:"");
-			$this->setData('sliderImageAltText', $sliderContent->getSliderImageAltText($locale)?:"");	
+			$this->setData('sliderImageAltText', $sliderContent->getSliderImageAltText($locale)?:"");
 		}
 	}
 
 	/**
 	 * Assign form data to user-submitted data.
 	 */
-	function readInputData() {	
+	function readInputData() {
 		$this->readUserVars(array('name','content','showContent','copyright','temporaryFileId','sliderImage',
 		'sliderImageAltText','sliderImageLink'));
 	}
@@ -81,7 +86,7 @@ class SliderContentForm extends Form {
 		$templateMgr->assign('sliderContentId', $this->sliderContentId);
 		$templateMgr->registerPlugin('function', 'plugin_url', array($this->plugin, 'smartyPluginUrl'));
 		$locale = $templateMgr->getTemplateVars('primaryLocale');
-		
+
 		if (!$this->sliderContentId) {
 			$this->setData('content', '');
 // "<div id='slider-text' class='slider-text'>
@@ -89,10 +94,13 @@ class SliderContentForm extends Form {
 // <p>Text
 // <a href='#'>Read more ...</a>
 // </p>
-// </div>");	
+// </div>");
 		} else {
 
-			$sliderHomeDao = new SliderHomeDAO();
+			/** @var SliderHomeDAO $sliderHomeDao */
+			$sliderHomeDao = DAORegistry::getDAO('SliderHomeDao');
+
+			/** @var SliderContent $sliderContent */
 			$sliderContent = $sliderHomeDao->getById($this->sliderContentId, $this->contextId);
 
 			// Slider image delete link action
@@ -127,25 +135,30 @@ class SliderContentForm extends Form {
 
 		$request = Application::get()->getRequest();
 
-		$sliderHomeDao = new SliderHomeDAO();
+		/** @var SliderHomeDAO $sliderHomeDao */
+		$sliderHomeDao = DAORegistry::getDAO('SliderHomeDao');
+
 		if ($this->sliderContentId) {
 			// Load and update an existing content
+			/** @var SliderContent $sliderContent */
 			$sliderContent = $sliderHomeDao->getById($this->sliderContentId, $this->contextId);
 		} else {
 			// Create a new item
+			/** @var SliderContent $sliderContent */
 			$sliderContent = $sliderHomeDao->newDataObject();
 			$sliderContent->setContextId($this->contextId);
-		}		
+		}
 		$sliderContent->setName($this->getData('name'));
 		$sliderContent->setContent($this->getData('content'));
-		$sliderContent->setShowContent(!empty($this->getData('showContent')));	
-		$sliderContent->setCopyright($this->getData('copyright'));	
+		$sliderContent->setShowContent(!empty($this->getData('showContent')));
+		$sliderContent->setCopyright($this->getData('copyright'));
 
 		$locale = AppLocale::getLocale();
 		// Copy an uploaded slider file
 		if ($temporaryFileId = $this->getData('temporaryFileId')?:"") {
 			$user = $request->getUser();
-			$temporaryFileDao = DAORegistry::getDAO('TemporaryFileDAO'); /* @var $temporaryFileDao TemporaryFileDAO */
+			/** @var TemporaryFileDao $temporaryFileDao */
+			$temporaryFileDao = DAORegistry::getDAO('TemporaryFileDao');
 			$temporaryFile = $temporaryFileDao->getTemporaryFile($temporaryFileId, $user->getId());
 
 			import('classes.file.PublicFileManager');
@@ -167,7 +180,7 @@ class SliderContentForm extends Form {
 			$sliderHomeDao->insertObject($sliderContent);
 		}
 	}
-	
+
 	/**
 	 * Perform additional validation checks
 	 * @copydoc Form::validate
@@ -176,7 +189,8 @@ class SliderContentForm extends Form {
 		if ($temporaryFileId = $this->getData('temporaryFileId')) {
 			$request = Application::get()->getRequest();
 			$user = $request->getUser();
-			$temporaryFileDao = DAORegistry::getDAO('TemporaryFileDAO'); /* @var $temporaryFileDao TemporaryFileDAO */
+			/** @var TemporaryFileDao $temporaryFileDao */
+			$temporaryFileDao = DAORegistry::getDAO('TemporaryFileDao');
 			$temporaryFile = $temporaryFileDao->getTemporaryFile($temporaryFileId, $user->getId());
 
 			import('classes.file.PublicFileManager');

--- a/controllers/tab/SliderHomeSettingsTabFormHandler.inc.php
+++ b/controllers/tab/SliderHomeSettingsTabFormHandler.inc.php
@@ -22,7 +22,7 @@ class SliderHomeSettingsTabFormHandler extends SettingsHandler {
 		$errors = [];
 
 		$plugin = PluginRegistry::getPlugin('generic', 'sliderhomeplugin');
-		$request = Application::getRequest();
+		$request = Application::get()->getRequest();
 		$contextId = $request->getContext()->getId();
 		$args = $request->_requestVars;
 		$response =& $functionArgs[1];
@@ -40,7 +40,7 @@ class SliderHomeSettingsTabFormHandler extends SettingsHandler {
 		if ($validator->fails()) {
 			$errors = $validator->errors();
 		}
-		  
+
 		if (!empty($errors)) {
 			return $response->withStatus(400)->withJson($errors);
 		}

--- a/templates/homeOMP.tpl
+++ b/templates/homeOMP.tpl
@@ -67,7 +67,7 @@
 							</a>
 						</h4>
 						<div class="date">
-							{$announcement->getDatePosted()}
+							{$announcement->getDatePosted()|date_format:$dateFormatShort}
 						</div>
 					</article>
 				{/if}


### PR DESCRIPTION
# Update SliderHome Plugin for OJS/OMP 3.3 Compatibility

## Description
Updates the SliderHome plugin to ensure compatibility with OJS/OMP 3.3.x and fix deprecation warnings.

## Key Changes

- **Compatibility**: Replace deprecated `Application::getRequest()` with `Application::get()->getRequest()`
- **DAO Pattern**: Implement proper DAO registry usage for `SliderHomeDAO`
- **Type Annotations**: Add PHPDoc annotations for better IDE support
- **Template Fix**: Correct date formatting in `homeOMP.tpl`
- **File Management**: Improve file deletion operations in grid handler